### PR TITLE
Adjust makefile compile and bench targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,34 +1,21 @@
-REBAR2=rebar
-REBAR3=rebar3
-RIAK_PB=_build/default/lib/riak_pb
-KATJA=_build/default/lib/katja
+REBAR=rebar3
 BENCH=_build/default/lib/basho_bench
-BENCH_HRL=basho_bench
 EBIN=_build/default/lib/fmk/ebin
 CLIENT=basho_bench_driver_fmkclient
 
 all: compile rel
 
 compile:
-	./${REBAR3} compile; \
-	cp ${RIAK_PB}/rebar ${KATJA}/ ; \
-	cd ${RIAK_PB}; ${REBAR2} get-deps; ${REBAR2} compile; \
-	cd - ; \
-	cd ${KATJA}; ${REBAR2} get-deps; ${REBAR2} compile; \
-	cd - ; \
+	${REBAR} compile; \
 	cd ${BENCH}; make all; \
-	cd - ; \
-	./${REBAR3} compile; \
-	cp ${BENCH}/include/${BENCH_HRL}.hrl ./include/ ; \
+	cd -; \
+	cp ${BENCH}/include/basho_bench.hrl ./include/ ; \
 	erlc test/${CLIENT}.erl; \
 	mv ${CLIENT}.beam ${EBIN}/
 
 rel:
-	./${REBAR3} release
-
-relclean:
-	rm -rf _build/
+	${REBAR} release
 
 bench:
-	${BENCH}/basho_bench test/fmkclient.config; \
-	Rscript --vanilla _build/default/lib/basho_bench/priv/summary.r -i tests/current
+	${BENCH}/_build/default/bin/basho_bench test/fmkclient.config; \
+	Rscript --vanilla ${BENCH}/priv/summary.r -i tests/current

--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,12 @@ compile:
 rel:
 	${REBAR} release
 
-bench:
+relclean:
+	rm -rf _build
+
+bench: compile
 	${BENCH}/_build/default/bin/basho_bench test/fmkclient.config; \
 	Rscript --vanilla ${BENCH}/priv/summary.r -i tests/current
+
+console: rel
+	./_build/default/rel/fmk/bin/fmk console

--- a/test/fmkclient.config
+++ b/test/fmkclient.config
@@ -11,8 +11,8 @@
 {driver, basho_bench_driver_fmkclient}.
 
 %% necessary code to run the client (probably only needs FMK)
-{code_paths, ["/Users/goncalotomas/git/fmk--/_build/default/lib/fmk",
-"/Users/goncalotomas/git/basho_bench","/Users/goncalotomas/git/basho_bench/deps/lager"]}.
+{code_paths, ["_build/default/lib/fmk",
+"_build/default/lib/basho_bench","_build/default/lib/lager"]}.
 
 %%
 {key_generator, {int_to_bin_bigendian, {uniform_int, 5000000}}}.


### PR DESCRIPTION
With the new basho_bench dependency, it looks like the script `basho_bench` is not created on the repository root folder anymore but in `_build/default/bin`