### PR TITLE
Use connection pool for Antidote

### DIFF
--- a/include/fmk.hrl
+++ b/include/fmk.hrl
@@ -131,7 +131,7 @@
 -define (FMK_STAFF_NAME_INDEX, <<"staff_name_index">>).
 
 %% Type specification borrowed from antidote
--type txid() :: antidote:txid().
+-type txid() :: {pid(), antidote:txid()}.
 -type reason() :: antidote:reason().
 -type snapshot_time() :: antidote:snapshot_time().
 -type bound_object() :: antidote:bound_object().

--- a/rebar.config
+++ b/rebar.config
@@ -9,7 +9,8 @@
     {riak_dt, ".*", {git, "git://github.com/aletomsic/riak_dt", {tag, "type_check_antidote"}}},
     {basho_bench, {git, "https://github.com/SyncFree/basho_bench", {tag, "antidote_pb-rebar3-erlang19"}}},
     {antidote_pb, {git, "https://github.com/SyncFree/antidote_pb", {tag, "erlang19"}}},
-    {mochiweb, {git, "https://github.com/mochi/mochiweb", {tag, "master"}}}
+    {mochiweb, {git, "https://github.com/mochi/mochiweb", {tag, "master"}}},
+    {poolboy, {git, "https://github.com/devinus/poolboy", {tag, "1.5.1"}}}
   ]}.
 
 {relx, [{release, {fmk, "0.0.1"},

--- a/src/antidote_lib.erl
+++ b/src/antidote_lib.erl
@@ -214,14 +214,18 @@ counter_decrement(Amount) ->
 %% Returns an Antidote-compliant operation for assigning a value to a CRDT lww-register.
 -spec lwwreg_assign(term()) -> crdt_op().
 lwwreg_assign(Value) ->
-  {assign,Value}.
+  {assign, term_to_binary(Value)}.
 
 %% Returns an Antidote-compliant operation for adding a list of items to a CRDT set.
 -spec set_add_elements([term()]) -> crdt_op().
 set_add_elements(List) ->
-  {add_all, List}.
+  {add_all, build_binary_element_list(List)}.
 
 %% Returns an Antidote-compliant operation for removing a list of items from a CRDT set.
 -spec set_remove_elements([term()]) -> crdt_op().
 set_remove_elements(List) ->
-  {remove, List}.
+  {remove, build_binary_element_list(List)}.
+
+-spec build_binary_element_list([term()]) -> [binary()].
+build_binary_element_list(NormalList) ->
+  [term_to_binary(X) || X <- NormalList].

--- a/src/antidote_pool.erl
+++ b/src/antidote_pool.erl
@@ -1,0 +1,62 @@
+%%%-------------------------------------------------------------------
+%%% @author peter
+%%% @copyright (C) 2016, <COMPANY>
+%%% @doc
+%%%
+%%% @end
+%%% Created : 15. Nov 2016 14:03
+%%%-------------------------------------------------------------------
+-module(antidote_pool).
+-author("peter").
+
+-behaviour(poolboy_worker).
+-behaviour(supervisor).
+
+%% API
+-export([start/1, with_connection/1]).
+
+%% Supervisor callbacks
+-export([init/1]).
+
+%% Poolboy callbacks
+-export([start_link/1]).
+
+-define(SERVER, ?MODULE).
+
+%%%===================================================================
+%%% API functions
+%%%===================================================================
+
+start(Options) ->
+  supervisor:start_link({local, ?SERVER}, ?MODULE, [Options]).
+
+
+with_connection(Fun) ->
+  poolboy:transaction(antidote_connection_pool, Fun).
+
+
+%%%===================================================================
+%%% Supervisor callbacks
+%%%===================================================================
+
+init(Options) ->
+  Hostname = proplists:get_value(hostname, Options, "localhost"),
+  Port = proplists:get_value(port, Options, 8087),
+  PoolArgs = [
+    {name, {local, antidote_connection_pool}},
+    {worker_module, ?MODULE},
+    {size, 15},
+    {max_overflow, 0}
+  ],
+  WorkerArgs = [Hostname, Port],
+  PoolSpec = poolboy:child_spec(antidote_connection_pool, PoolArgs, WorkerArgs),
+  {ok, {{one_for_one, 10, 10}, [PoolSpec]}}.
+
+
+
+
+start_link([Hostname, Port]) ->
+  io:format("Connecting to ~p:~p~n", [Hostname, Port]),
+  {ok, Pid} = antidotec_pb_socket:start_link(Hostname, Port),
+  io:format("Connected to ~p:~p --> ~p ~n", [Hostname, Port, Pid]),
+  {ok, Pid}.

--- a/src/event.erl
+++ b/src/event.erl
@@ -23,8 +23,8 @@ new(Id,PatientId,StaffMemberId,Timestamp,Description) ->
   IdOp = build_id_op(?EVENT_ID,?EVENT_ID_CRDT,Id),
   PatientNameOp = build_id_op(?EVENT_PATIENT_ID,?EVENT_PATIENT_ID_CRDT,PatientId),
   StaffMemberNameOp = build_id_op(?EVENT_STAFF_ID,?EVENT_STAFF_ID_CRDT,StaffMemberId),
-  TimestampOp = build_lwwreg_op(?EVENT_TIMESTAMP,?EVENT_TIMESTAMP_CRDT,list_to_binary(Timestamp)),
-  DescriptionOp = build_lwwreg_op(?EVENT_DESCRIPTION,?EVENT_DESCRIPTION_CRDT,list_to_binary(Description)),
+  TimestampOp = build_lwwreg_op(?EVENT_TIMESTAMP,?EVENT_TIMESTAMP_CRDT,Timestamp),
+  DescriptionOp = build_lwwreg_op(?EVENT_DESCRIPTION,?EVENT_DESCRIPTION_CRDT,Description),
   [IdOp,PatientNameOp,StaffMemberNameOp,TimestampOp,DescriptionOp].
 
 %% Returns the patient ID from an already existant event object.

--- a/src/facility.erl
+++ b/src/facility.erl
@@ -26,18 +26,18 @@
 -spec new(id(),string(),string(),string()) -> [term()].
 new(Id,Name,Address,Type) ->
   IdOp = build_id_op(?FACILITY_ID,?FACILITY_ID_CRDT,Id),
-  NameOp = build_lwwreg_op(?FACILITY_NAME,?FACILITY_NAME_CRDT,list_to_binary(Name)),
-  AddressOp = build_lwwreg_op(?FACILITY_ADDRESS,?FACILITY_ADDRESS_CRDT,list_to_binary(Address)),
-  TypeOp = build_lwwreg_op(?FACILITY_TYPE,?FACILITY_TYPE_CRDT,list_to_binary(Type)),
+  NameOp = build_lwwreg_op(?FACILITY_NAME,?FACILITY_NAME_CRDT,Name),
+  AddressOp = build_lwwreg_op(?FACILITY_ADDRESS,?FACILITY_ADDRESS_CRDT,Address),
+  TypeOp = build_lwwreg_op(?FACILITY_TYPE,?FACILITY_TYPE_CRDT,Type),
   [IdOp,NameOp,AddressOp,TypeOp].
 
 %% Returns a list of operations ready to be inserted into antidote, with the purpose
 %% of updating a specific facility's details.
 -spec update_details(string(),string(),string()) -> [term()].
 update_details(Name,Address,Type) ->
-  NameOp = build_lwwreg_op(?FACILITY_NAME,?FACILITY_NAME_CRDT,list_to_binary(Name)),
-  AddressOp = build_lwwreg_op(?FACILITY_ADDRESS,?FACILITY_ADDRESS_CRDT,list_to_binary(Address)),
-  TypeOp = build_lwwreg_op(?FACILITY_TYPE,?FACILITY_TYPE_CRDT,list_to_binary(Type)),
+  NameOp = build_lwwreg_op(?FACILITY_NAME,?FACILITY_NAME_CRDT,Name),
+  AddressOp = build_lwwreg_op(?FACILITY_ADDRESS,?FACILITY_ADDRESS_CRDT,Address),
+  TypeOp = build_lwwreg_op(?FACILITY_TYPE,?FACILITY_TYPE_CRDT,Type),
   [NameOp,AddressOp,TypeOp].
 
 %% Returns the facility name as from a facility object
@@ -77,7 +77,7 @@ add_treatment(TreatmentId, PatientId, PrescriberId, DateStarted) ->
   TreatmentIdOp = build_id_op(?TREATMENT_ID,?TREATMENT_ID_CRDT,TreatmentId),
   PatientIdOp = build_id_op(?PATIENT_ID,?PATIENT_ID_CRDT,PatientId),
   PrescriberIdOp = build_id_op(?STAFF_ID,?STAFF_ID_CRDT,PrescriberId),
-  DateStartedOp = build_lwwreg_op(?TREATMENT_DATE_PRESCRIBED,?TREATMENT_DATE_PRESCRIBED_CRDT,list_to_binary(DateStarted)),
+  DateStartedOp = build_lwwreg_op(?TREATMENT_DATE_PRESCRIBED,?TREATMENT_DATE_PRESCRIBED_CRDT,DateStarted),
   ListOps = [TreatmentIdOp,PrescriberIdOp,PatientIdOp,DateStartedOp],
   %% now to insert the nested operations inside the treatments map
   FacilityTreatmentKey = fmk_core:binary_treatment_key(TreatmentId),
@@ -92,8 +92,8 @@ add_treatment(TreatmentId, PatientId, PrescriberId, DateStarted, DateEnded) ->
   TreatmentIdOp = build_id_op(?TREATMENT_ID,?TREATMENT_ID_CRDT,TreatmentId),
   PatientIdOp = build_id_op(?PATIENT_ID,?PATIENT_ID_CRDT,PatientId),
   PrescriberIdOp = build_id_op(?STAFF_ID,?STAFF_ID_CRDT,PrescriberId),
-  DateStartedOp = build_lwwreg_op(?TREATMENT_DATE_PRESCRIBED,?TREATMENT_DATE_PRESCRIBED_CRDT,list_to_binary(DateStarted)),
-  DateEndedOp = build_lwwreg_op(?TREATMENT_DATE_PRESCRIBED,?TREATMENT_DATE_PRESCRIBED_CRDT,list_to_binary(DateEnded)),
+  DateStartedOp = build_lwwreg_op(?TREATMENT_DATE_PRESCRIBED,?TREATMENT_DATE_PRESCRIBED_CRDT,DateStarted),
+  DateEndedOp = build_lwwreg_op(?TREATMENT_DATE_PRESCRIBED,?TREATMENT_DATE_PRESCRIBED_CRDT,DateEnded),
   ListOps = [TreatmentIdOp,PrescriberIdOp,PatientIdOp,DateStartedOp,DateEndedOp],
   %% now to insert the nested operations inside the treatments map
   FacilityTreatmentKey = fmk_core:binary_treatment_key(TreatmentId),
@@ -124,7 +124,8 @@ process_prescription(PrescriptionId, CurrentDate) ->
   %% now to insert the nested operations inside the prescriptions map
   FacilityPrescriptionsKey = fmk_core:binary_prescription_key(PrescriptionId),
   %% return a top level patient update that contains the prescriptions map update
-  FacilityPrescriptionsOp = antidote_lib:build_nested_map_op(?FACILITY_PRESCRIPTIONS,?NESTED_MAP,FacilityPrescriptionsKey,PrescriptionUpdate),
+  FacilityPrescriptionsOp = antidote_lib:build_nested_map_op(?FACILITY_PRESCRIPTIONS,?NESTED_MAP,
+  FacilityPrescriptionsKey,PrescriptionUpdate),
   [FacilityPrescriptionsOp].
 
 -spec add_prescription_drugs(id(), [string()]) -> [term()].
@@ -133,7 +134,8 @@ add_prescription_drugs(PrescriptionId, Drugs) ->
   %% now to insert the nested operations inside the prescriptions map
   FacilityPrescriptionsKey = fmk_core:binary_prescription_key(PrescriptionId),
   %% return a top level patient update that contains the prescriptions map update
-  FacilityPrescriptionsOp = antidote_lib:build_nested_map_op(?FACILITY_PRESCRIPTIONS,?NESTED_MAP,FacilityPrescriptionsKey,PrescriptionUpdate),
+  FacilityPrescriptionsOp = antidote_lib:build_nested_map_op(?FACILITY_PRESCRIPTIONS,
+  ?NESTED_MAP,FacilityPrescriptionsKey,PrescriptionUpdate),
   [FacilityPrescriptionsOp].
 
 %% Returns an update operation for adding an event to a specific facility treatment.

--- a/src/fmk.app.src
+++ b/src/fmk.app.src
@@ -11,7 +11,8 @@
     mochiweb,
     antidote_crdt,
     antidote_pb,
-    riak_pb
+    riak_pb,
+    poolboy
    ]},
   {env,[]},
   {modules, []},

--- a/src/fmk_app.erl
+++ b/src/fmk_app.erl
@@ -45,13 +45,8 @@ open_antidote_socket() ->
     set_application_variable(antidote_port,"ANTIDOTE_PORT",?DEFAULT_ANTIDOTE_PORT),
     AntidoteNodeAddress = fmk_config:get_env(?VAR_ANTIDOTE_PB_ADDRESS,?DEFAULT_ANTIDOTE_ADDRESS),
     AntidoteNodePort = fmk_config:get_env(?VAR_ANTIDOTE_PB_PORT,?DEFAULT_ANTIDOTE_PORT),
-    case antidotec_pb_socket:start(AntidoteNodeAddress, AntidoteNodePort) of
-        {ok, Pid} ->
-            fmk_config:set(?VAR_ANTIDOTE_PB_PID,pid_to_list(Pid)),
-            ok;
-        _SomethingElse ->
-            {error, _SomethingElse}
-    end.
+    {ok, _} =antidote_pool:start([{hostname, AntidoteNodeAddress}, {port, AntidoteNodePort}]),
+    ok.
 
 close_antidote_socket() ->
     AntidotePbPid = fmk_config:get(?VAR_ANTIDOTE_PB_PID,undefined),

--- a/src/patient.erl
+++ b/src/patient.erl
@@ -27,16 +27,16 @@
 -spec new(id(),string(),string()) -> [term()].
 new(Id,Name,Address) ->
   IdOp = build_id_op(?PATIENT_ID,?PATIENT_ID_CRDT,Id),
-  NameOp = build_lwwreg_op(?PATIENT_NAME,?PATIENT_NAME_CRDT,list_to_binary(Name)),
-  AddressOp = build_lwwreg_op(?PATIENT_ADDRESS,?PATIENT_ADDRESS_CRDT,list_to_binary(Address)),
+  NameOp = build_lwwreg_op(?PATIENT_NAME,?PATIENT_NAME_CRDT,Name),
+  AddressOp = build_lwwreg_op(?PATIENT_ADDRESS,?PATIENT_ADDRESS_CRDT,Address),
   [IdOp,NameOp,AddressOp].
 
 %% Returns a list of operations ready to be inserted into antidote, with the purpose
 %% of updating a specific pharmacy's details.
 -spec update_details(string(),string()) -> [term()].
 update_details(Name,Address) ->
-  NameOp = build_lwwreg_op(?PATIENT_NAME,?PATIENT_NAME_CRDT,list_to_binary(Name)),
-  AddressOp = build_lwwreg_op(?PATIENT_ADDRESS,?PATIENT_ADDRESS_CRDT,list_to_binary(Address)),
+  NameOp = build_lwwreg_op(?PATIENT_NAME,?PATIENT_NAME_CRDT,Name),
+  AddressOp = build_lwwreg_op(?PATIENT_ADDRESS,?PATIENT_ADDRESS_CRDT,Address),
   [NameOp,AddressOp].
 
 %% Returns the patient name as a list from a patient object
@@ -76,7 +76,7 @@ add_treatment(TreatmentId, PrescriberId, FacilityId, DateStarted) ->
   TreatmentIdOp = build_id_op(?TREATMENT_ID,?TREATMENT_ID_CRDT,TreatmentId),
   PrescriberIdOp = build_id_op(?TREATMENT_PRESCRIBER_ID,?TREATMENT_PRESCRIBER_ID_CRDT,PrescriberId),
   FacilityIdOp = build_id_op(?TREATMENT_FACILITY_ID,?TREATMENT_FACILITY_ID_CRDT,FacilityId),
-  DateStartedOp = build_lwwreg_op(?TREATMENT_DATE_PRESCRIBED,?TREATMENT_DATE_PRESCRIBED_CRDT,list_to_binary(DateStarted)),
+  DateStartedOp = build_lwwreg_op(?TREATMENT_DATE_PRESCRIBED,?TREATMENT_DATE_PRESCRIBED_CRDT,DateStarted),
   ListOps = [TreatmentIdOp,PrescriberIdOp,FacilityIdOp,DateStartedOp],
   %% now to insert the nested operations inside the treatments map
   PatientTreatmentKey = fmk_core:binary_treatment_key(TreatmentId),
@@ -91,8 +91,8 @@ add_treatment(TreatmentId, PrescriberId, FacilityId, DateStarted, DateEnded) ->
   TreatmentIdOp = build_id_op(?TREATMENT_ID,?TREATMENT_ID_CRDT,TreatmentId),
   PrescriberIdOp = build_id_op(?TREATMENT_PRESCRIBER_ID,?TREATMENT_PRESCRIBER_ID_CRDT,PrescriberId),
   FacilityIdOp = build_id_op(?TREATMENT_FACILITY_ID,?TREATMENT_FACILITY_ID_CRDT,FacilityId),
-  DateStartedOp = build_lwwreg_op(?TREATMENT_DATE_PRESCRIBED,?TREATMENT_DATE_PRESCRIBED_CRDT,list_to_binary(DateStarted)),
-  DateEndedOp = build_lwwreg_op(?TREATMENT_DATE_ENDED,?TREATMENT_DATE_ENDED_CRDT,list_to_binary(DateEnded)),
+  DateStartedOp = build_lwwreg_op(?TREATMENT_DATE_PRESCRIBED,?TREATMENT_DATE_PRESCRIBED_CRDT,DateStarted),
+  DateEndedOp = build_lwwreg_op(?TREATMENT_DATE_ENDED,?TREATMENT_DATE_ENDED_CRDT,DateEnded),
   ListOps = [TreatmentIdOp,PrescriberIdOp,FacilityIdOp,DateStartedOp,DateEndedOp],
   %% now to insert the nested operations inside the treatments map
   PatientTreatmentKey = fmk_core:binary_treatment_key(TreatmentId),
@@ -132,7 +132,8 @@ add_prescription_drugs(PrescriptionId, Drugs) ->
   %% now to insert the nested operations inside the prescriptions map
   PatientPrescriptionsKey = fmk_core:binary_prescription_key(PrescriptionId),
   %% return a top level patient update that contains the prescriptions map update
-  PatientPrescriptionsOp = antidote_lib:build_nested_map_op(?PATIENT_PRESCRIPTIONS,?NESTED_MAP,PatientPrescriptionsKey,PrescriptionUpdate),
+  PatientPrescriptionsOp = antidote_lib:build_nested_map_op(?PATIENT_PRESCRIPTIONS,?NESTED_MAP,
+  PatientPrescriptionsKey,PrescriptionUpdate),
   [PatientPrescriptionsOp].
 
 % Returns an update operation for adding an event to a specific patient.

--- a/src/pharmacy.erl
+++ b/src/pharmacy.erl
@@ -21,16 +21,16 @@
 -spec new(id(),string(),string()) -> [term()].
 new(Id,Name,Address) ->
   IdOp = build_id_op(?PHARMACY_ID,?PHARMACY_ID_CRDT,Id),
-  NameOp = build_lwwreg_op(?PHARMACY_NAME,?PHARMACY_NAME_CRDT,list_to_binary(Name)),
-  AddressOp = build_lwwreg_op(?PHARMACY_ADDRESS,?PHARMACY_ADDRESS_CRDT,list_to_binary(Address)),
+  NameOp = build_lwwreg_op(?PHARMACY_NAME,?PHARMACY_NAME_CRDT,Name),
+  AddressOp = build_lwwreg_op(?PHARMACY_ADDRESS,?PHARMACY_ADDRESS_CRDT,Address),
   [IdOp,NameOp,AddressOp].
 
 %% Returns a list of operations ready to be inserted into antidote, with the purpose
 %% of updating a specific pharmacy's details.
 -spec update_details(string(),string()) -> [term()].
 update_details(Name,Address) ->
-  NameOp = build_lwwreg_op(?PHARMACY_NAME,?PHARMACY_NAME_CRDT,list_to_binary(Name)),
-  AddressOp = build_lwwreg_op(?PHARMACY_ADDRESS,?PHARMACY_ADDRESS_CRDT,list_to_binary(Address)),
+  NameOp = build_lwwreg_op(?PHARMACY_NAME,?PHARMACY_NAME_CRDT,Name),
+  AddressOp = build_lwwreg_op(?PHARMACY_ADDRESS,?PHARMACY_ADDRESS_CRDT,Address),
   [NameOp,AddressOp].
 
 %% Returns the name of the pharmacy in the form of a list.
@@ -85,7 +85,8 @@ add_prescription_drugs(PrescriptionId, Drugs) ->
   %% now to insert the nested operations inside the prescriptions map
   PharmacyPrescriptionsKey = fmk_core:binary_prescription_key(PrescriptionId),
   %% return a top level patient update that contains the prescriptions map update
-  PharmacyPrescriptionsOp = antidote_lib:build_nested_map_op(?PHARMACY_PRESCRIPTIONS,?NESTED_MAP,PharmacyPrescriptionsKey,PrescriptionUpdate),
+  PharmacyPrescriptionsOp = antidote_lib:build_nested_map_op(?PHARMACY_PRESCRIPTIONS,?NESTED_MAP,
+  PharmacyPrescriptionsKey,PrescriptionUpdate),
   [PharmacyPrescriptionsOp].
 
 %%-----------------------------------------------------------------------------

--- a/src/prescription.erl
+++ b/src/prescription.erl
@@ -33,7 +33,7 @@ new(Id,PatientId,PrescriberId,PharmacyId,FacilityId,DatePrescribed,Drugs) ->
   PharmacyOp = build_id_op(?PRESCRIPTION_PHARMACY_ID,?PRESCRIPTION_PHARMACY_ID_CRDT,PharmacyId),
   FacilityOp = build_id_op(?PRESCRIPTION_FACILITY_ID,?PRESCRIPTION_FACILITY_ID_CRDT,FacilityId),
   PrescriberOp = build_id_op(?PRESCRIPTION_PRESCRIBER_ID,?PRESCRIPTION_PRESCRIBER_ID_CRDT,PrescriberId),
-  DatePrescribedOp = build_lwwreg_op(?PRESCRIPTION_DATE_PRESCRIBED,?PRESCRIPTION_DATE_PRESCRIBED_CRDT,list_to_binary(DatePrescribed)),
+  DatePrescribedOp = build_lwwreg_op(?PRESCRIPTION_DATE_PRESCRIBED,?PRESCRIPTION_DATE_PRESCRIBED_CRDT,DatePrescribed),
   IsProcessedOp = build_lwwreg_op(?PRESCRIPTION_IS_PROCESSED,?PRESCRIPTION_IS_PROCESSED_CRDT,?PRESCRIPTION_NOT_PROCESSED),
   [DrugsOp] = add_drugs(Drugs),
   [IdOp,PatientOp,PharmacyOp,FacilityOp,PrescriberOp,DatePrescribedOp,IsProcessedOp,DrugsOp].
@@ -45,7 +45,7 @@ new(Id,PatientId,PrescriberId,PharmacyId,FacilityId,DatePrescribed,DateProcessed
   [IdOp,PatientOp,PharmacyOp,FacilityOp,PrescriberOp,DatePrescribedOp,DateProcessedOp,_OldIsProcessedOp,DrugsOp] =
     new(Id,PatientId,PrescriberId,PharmacyId,FacilityId,DatePrescribed,Drugs),
   %% trying to keep DRY code by calling new/7 and discarding unnecessary ops
-  DateProcessedOp = build_lwwreg_op(?PRESCRIPTION_DATE_PRESCRIBED,?PRESCRIPTION_DATE_PRESCRIBED_CRDT,list_to_binary(DateProcessed)),
+  DateProcessedOp = build_lwwreg_op(?PRESCRIPTION_DATE_PRESCRIBED,?PRESCRIPTION_DATE_PRESCRIBED_CRDT,DateProcessed),
   IsProcessedOp = build_lwwreg_op(?PRESCRIPTION_IS_PROCESSED,?PRESCRIPTION_IS_PROCESSED_CRDT,?PRESCRIPTION_PROCESSED),
   [IdOp,PatientOp,PharmacyOp,FacilityOp,PrescriberOp,DatePrescribedOp,DateProcessedOp,IsProcessedOp,DrugsOp].
 

--- a/src/staff.erl
+++ b/src/staff.erl
@@ -23,9 +23,9 @@
 -spec new(id(),string(),string(),string()) -> [term()].
 new(Id,Name,Address,Speciality) ->
   IdOp = build_id_op(?STAFF_ID,?STAFF_ID_CRDT,Id),
-  NameOp = build_lwwreg_op(?STAFF_NAME,?STAFF_NAME_CRDT,list_to_binary(Name)),
-  AddressOp = build_lwwreg_op(?STAFF_ADDRESS,?STAFF_ADDRESS_CRDT,list_to_binary(Address)),
-  SpecialityOp = build_lwwreg_op(?STAFF_SPECIALITY,?STAFF_SPECIALITY_CRDT,list_to_binary(Speciality)),
+  NameOp = build_lwwreg_op(?STAFF_NAME,?STAFF_NAME_CRDT,Name),
+  AddressOp = build_lwwreg_op(?STAFF_ADDRESS,?STAFF_ADDRESS_CRDT,Address),
+  SpecialityOp = build_lwwreg_op(?STAFF_SPECIALITY,?STAFF_SPECIALITY_CRDT,Speciality),
   %% initially a staff member does not have any treatments or prescriptions
   [IdOp,NameOp,AddressOp,SpecialityOp].
 
@@ -33,9 +33,9 @@ new(Id,Name,Address,Speciality) ->
 %% Update operation: updates only the staff member's personal details
 -spec update_details(string(),string(),string()) -> [term()].
 update_details(Name,Address,Speciality) ->
-  NameOp = build_lwwreg_op(?STAFF_NAME,?STAFF_NAME_CRDT,list_to_binary(Name)),
-  AddressOp = build_lwwreg_op(?STAFF_ADDRESS,?STAFF_ADDRESS_CRDT,list_to_binary(Address)),
-  SpecialityOp = build_lwwreg_op(?STAFF_SPECIALITY,?STAFF_SPECIALITY_CRDT,list_to_binary(Speciality)),
+  NameOp = build_lwwreg_op(?STAFF_NAME,?STAFF_NAME_CRDT,Name),
+  AddressOp = build_lwwreg_op(?STAFF_ADDRESS,?STAFF_ADDRESS_CRDT,Address),
+  SpecialityOp = build_lwwreg_op(?STAFF_SPECIALITY,?STAFF_SPECIALITY_CRDT,Speciality),
   [NameOp,AddressOp,SpecialityOp].
 
 %% Returns the name in the form of a list from a staff member object.
@@ -100,7 +100,8 @@ add_prescription_drugs(PrescriptionId, Drugs) ->
   %% now to insert the nested operations inside the prescriptions map
   StaffPrescriptionsKey = fmk_core:binary_prescription_key(PrescriptionId),
   %% return a top level patient update that contains the prescriptions map update
-  StaffPrescriptionsOp = antidote_lib:build_nested_map_op(?STAFF_PRESCRIPTIONS,?NESTED_MAP,StaffPrescriptionsKey,PrescriptionUpdate),
+  StaffPrescriptionsOp = antidote_lib:build_nested_map_op(?STAFF_PRESCRIPTIONS,?NESTED_MAP,
+  StaffPrescriptionsKey,PrescriptionUpdate),
   [StaffPrescriptionsOp].
 
 %%-----------------------------------------------------------------------------

--- a/src/treatment.erl
+++ b/src/treatment.erl
@@ -32,7 +32,7 @@ new(Id,PatientId,PrescriberId,FacilityId,DatePrescribed) ->
   PatientIdOp = build_id_op(?TREATMENT_PATIENT_ID,?TREATMENT_PATIENT_ID_CRDT,PatientId),
   PrescriberIdOp = build_id_op(?TREATMENT_PRESCRIBER_ID,?TREATMENT_PRESCRIBER_ID_CRDT,PrescriberId),
   FacilityIdOp = build_id_op(?TREATMENT_FACILITY_ID,?TREATMENT_FACILITY_ID_CRDT,FacilityId),
-  DatePrescribedOp = build_lwwreg_op(?TREATMENT_DATE_PRESCRIBED,?TREATMENT_DATE_PRESCRIBED_CRDT,list_to_binary(DatePrescribed)),
+  DatePrescribedOp = build_lwwreg_op(?TREATMENT_DATE_PRESCRIBED,?TREATMENT_DATE_PRESCRIBED_CRDT,DatePrescribed),
   HasEndedOp = build_lwwreg_op(?TREATMENT_HAS_ENDED,?TREATMENT_HAS_ENDED_CRDT,?TREATMENT_ONGOING),
   [IdOp,PatientIdOp,PrescriberIdOp,FacilityIdOp,DatePrescribedOp,HasEndedOp].
 
@@ -44,7 +44,7 @@ new(Id,PatientId,PrescriberId,FacilityId,DatePrescribed,DateEnded) ->
   [IdOp,PatientIdOp,PrescriberIdOp,FacilityIdOp,DatePrescribedOp,_IncorrectHasEndedOp] =
     new(Id,PatientId,PrescriberId,FacilityId,DatePrescribed),
   %% build missing ops
-  DateEndedOp = build_lwwreg_op(?TREATMENT_DATE_PRESCRIBED,?TREATMENT_DATE_PRESCRIBED_CRDT,list_to_binary(DateEnded)),
+  DateEndedOp = build_lwwreg_op(?TREATMENT_DATE_PRESCRIBED,?TREATMENT_DATE_PRESCRIBED_CRDT,DateEnded),
   HasEndedOp = build_lwwreg_op(?TREATMENT_HAS_ENDED,?TREATMENT_HAS_ENDED_CRDT,?TREATMENT_ENDED),
   [IdOp,PatientIdOp,PrescriberIdOp,FacilityIdOp,DatePrescribedOp,DateEndedOp,HasEndedOp].
 
@@ -98,7 +98,7 @@ has_ended(Treatment) ->
 -spec finish(string()) -> [term()].
 finish(CurrentDate) ->
   IsProcessedOp = build_lwwreg_op(?TREATMENT_HAS_ENDED,?TREATMENT_HAS_ENDED_CRDT,?TREATMENT_ENDED),
-  ProcessedOp = build_lwwreg_op(?TREATMENT_DATE_ENDED,?TREATMENT_DATE_ENDED_CRDT,list_to_binary(CurrentDate)),
+  ProcessedOp = build_lwwreg_op(?TREATMENT_DATE_ENDED,?TREATMENT_DATE_ENDED_CRDT,CurrentDate),
   [IsProcessedOp,ProcessedOp].
 
 %% Returns a list of antidote operation to add a nested prescription to a treatment.
@@ -112,7 +112,7 @@ add_prescription(PrescriptionId,PatientId,PrescriberId,PharmacyId,FacilityId,Dat
   PrescriberIdOp = build_id_op(?PRESCRIPTION_PRESCRIBER_ID,?PRESCRIPTION_PRESCRIBER_ID_CRDT,PrescriberId),
   PharmacyIdOp = build_id_op(?PRESCRIPTION_PHARMACY_ID,?PRESCRIPTION_PHARMACY_ID_CRDT,PharmacyId),
   FacilityIdOp = build_id_op(?PRESCRIPTION_FACILITY_ID,?PRESCRIPTION_FACILITY_ID_CRDT,FacilityId),
-  DateStartedOp = build_lwwreg_op(?PRESCRIPTION_DATE_PRESCRIBED,?PRESCRIPTION_DATE_PRESCRIBED_CRDT,list_to_binary(DatePrescribed)),
+  DateStartedOp = build_lwwreg_op(?PRESCRIPTION_DATE_PRESCRIBED,?PRESCRIPTION_DATE_PRESCRIBED_CRDT,DatePrescribed),
   [DrugsOp] = prescription:add_drugs(Drugs),
   ListOps = [PrescriptionIdOp,PatientIdOp,PrescriberIdOp,PharmacyIdOp,FacilityIdOp,DateStartedOp,DrugsOp],
   %% the nested prescription will be indexed by its key.
@@ -129,8 +129,8 @@ add_event(EventId,StaffMemberId,Timestamp,Description) ->
   %% nested operations
   EventIdOp = build_id_op(?EVENT_ID,?EVENT_ID_CRDT,EventId),
   PrescriberIdOp = build_id_op(?EVENT_STAFF_ID,?EVENT_STAFF_ID_CRDT,StaffMemberId),
-  TimestampOp = build_lwwreg_op(?EVENT_TIMESTAMP,?EVENT_TIMESTAMP_CRDT,list_to_binary(Timestamp)),
-  DescriptionOp = build_lwwreg_op(?EVENT_DESCRIPTION,?EVENT_DESCRIPTION_CRDT,list_to_binary(Description)),
+  TimestampOp = build_lwwreg_op(?EVENT_TIMESTAMP,?EVENT_TIMESTAMP_CRDT,Timestamp),
+  DescriptionOp = build_lwwreg_op(?EVENT_DESCRIPTION,?EVENT_DESCRIPTION_CRDT,Description),
   ListOps = [EventIdOp,PrescriberIdOp,TimestampOp,DescriptionOp],
   %% the nested event will be indexed by its key.
   PatientEventKey = fmk_core:binary_event_key(EventId),

--- a/test/basho_bench_driver_fmkclient.erl
+++ b/test/basho_bench_driver_fmkclient.erl
@@ -113,7 +113,7 @@ run(create_prescription, _GeneratedKey, _GeneratedValue, State) ->
   PharmacyId = rand:uniform(NumPharmacies),
   FacilityId = rand:uniform(NumFacilities),
   DatePrescribed = "1/1/2016",
-  Drugs = [<<"Adderall">>,<<"Amitriptyline">>],
+  Drugs = ["Adderall","Amitriptyline"],
   %% call create_prescription
   Result = run_op(FmkNode,create_prescription,[
     PrescriptionId,PatientId,PrescriberId,PharmacyId,FacilityId,DatePrescribed,Drugs
@@ -203,7 +203,7 @@ run(update_prescription_medication, _GeneratedKey, _GeneratedValue, State) ->
   NumPrescriptions = State#state.numprescriptions,
   PrescriptionId = rand:uniform(NumPrescriptions),
   FmkNode = State#state.fmknode,
-  Drugs = [<<"Amoxicillin">>,<<"Ativan">>,<<"Atorvastatin">>],
+  Drugs = ["Amoxicillin","Ativan","Atorvastatin"],
   Result = run_op(FmkNode,update_prescription_medication,[PrescriptionId,add_drugs,Drugs]),
   case Result of
     ok -> {ok, State};

--- a/test/basho_bench_driver_fmkclient.erl
+++ b/test/basho_bench_driver_fmkclient.erl
@@ -113,7 +113,7 @@ run(create_prescription, _GeneratedKey, _GeneratedValue, State) ->
   PharmacyId = rand:uniform(NumPharmacies),
   FacilityId = rand:uniform(NumFacilities),
   DatePrescribed = "1/1/2016",
-  Drugs = ["Adderall","Amitriptyline"],
+  Drugs = [<<"Adderall">>,<<"Amitriptyline">>],
   %% call create_prescription
   Result = run_op(FmkNode,create_prescription,[
     PrescriptionId,PatientId,PrescriberId,PharmacyId,FacilityId,DatePrescribed,Drugs
@@ -122,7 +122,7 @@ run(create_prescription, _GeneratedKey, _GeneratedValue, State) ->
   case Result of
     ok -> {ok,State};
     {badrpc,{'EXIT',{{badmatch,{error,{aborted,_Txn}}},_Trace}}} -> {error, txn_aborted, State};
-    _ -> {error, unknown, State}
+    Error -> {error, Error, State}
   end;
 
 run(get_pharmacy_prescriptions, _GeneratedKey, _GeneratedValue, State) ->
@@ -135,7 +135,7 @@ run(get_pharmacy_prescriptions, _GeneratedKey, _GeneratedValue, State) ->
     [] -> {ok,State};
     [_H|_T] -> {ok,State};
     {badrpc,{'EXIT',{{badmatch,{error,{aborted,_Txn}}},_Trace}}} -> {error, txn_aborted, State};
-    _ -> {error, unknown, State}
+    Error -> {error, Error, State}
   end;
 
 run(get_prescription_medication, _GeneratedKey, _GeneratedValue, State) ->
@@ -147,7 +147,7 @@ run(get_prescription_medication, _GeneratedKey, _GeneratedValue, State) ->
   case Prescription of
     [_H|_T] -> {ok,State};
     {badrpc,{'EXIT',{{badmatch,{error,{aborted,_Txn}}},_Trace}}} -> {error, txn_aborted, State};
-    _ -> {error, unknown, State}
+    Error -> {error, Error, State}
   end;
 
 run(get_staff_prescriptions, _GeneratedKey, _GeneratedValue, State) ->
@@ -159,7 +159,7 @@ run(get_staff_prescriptions, _GeneratedKey, _GeneratedValue, State) ->
     [] -> {ok,State};
     [_H|_T] -> {ok,State};
     {badrpc,{'EXIT',{{badmatch,{error,{aborted,_Txn}}},_Trace}}} -> {error, txn_aborted, State};
-    _ -> {error, unknown, State}
+    Error -> {error, Error, State}
   end;
 
 run(get_processed_prescriptions, _GeneratedKey, _GeneratedValue, State) ->
@@ -171,7 +171,7 @@ run(get_processed_prescriptions, _GeneratedKey, _GeneratedValue, State) ->
     [] -> {ok,State};
     [_H|_T] -> {ok,State};
     {badrpc,{'EXIT',{{badmatch,{error,{aborted,_Txn}}},_Trace}}} -> {error, txn_aborted, State};
-    _ -> {error, unknown, State}
+    Error -> {error, Error, State}
   end;
 
 run(get_patient, _GeneratedKey, _GeneratedValue, State) ->
@@ -183,7 +183,7 @@ run(get_patient, _GeneratedKey, _GeneratedValue, State) ->
   case Patient of
     [_H|_T] -> {ok,State};
     {badrpc,{'EXIT',{{badmatch,{error,{aborted,_Txn}}},_Trace}}} -> {error, txn_aborted, State};
-    _ -> {error, unknown, State}
+    Error -> {error, Error, State}
   end;
 
 run(update_prescription, _GeneratedKey, _GeneratedValue, State) ->
@@ -196,19 +196,19 @@ run(update_prescription, _GeneratedKey, _GeneratedValue, State) ->
     ok -> {ok, State};
     {error,prescription_already_processed} -> {ok, State}; % not an operation related error
     {badrpc,{'EXIT',{{badmatch,{error,{aborted,_Txn}}},_Trace}}} -> {error, txn_aborted, State};
-    _ -> {error, unknown, State}
+    Error -> {error, Error, State}
   end;
 
 run(update_prescription_medication, _GeneratedKey, _GeneratedValue, State) ->
   NumPrescriptions = State#state.numprescriptions,
   PrescriptionId = rand:uniform(NumPrescriptions),
   FmkNode = State#state.fmknode,
-  Drugs = ["Amoxicillin","Ativan","Atorvastatin"],
+  Drugs = [<<"Amoxicillin">>,<<"Ativan">>,<<"Atorvastatin">>],
   Result = run_op(FmkNode,update_prescription_medication,[PrescriptionId,add_drugs,Drugs]),
   case Result of
     ok -> {ok, State};
     {badrpc,{'EXIT',{{badmatch,{error,{aborted,_Txn}}},_Trace}}} -> {error, txn_aborted, State};
-    _ -> {error, unknown, State}
+    Error -> {error, Error, State}
   end;
 
 run(get_prescription, _GeneratedKey, _GeneratedValue, State) ->
@@ -220,7 +220,7 @@ run(get_prescription, _GeneratedKey, _GeneratedValue, State) ->
   case Prescription of
     [_H|_T] -> {ok,State};
     {badrpc,{'EXIT',{{badmatch,{error,{aborted,_Txn}}},_Trace}}} -> {error, txn_aborted, State};
-    _ -> {error, unknown, State}
+    Error -> {error, Error, State}
   end.
 
 run_op(FmkNode,Op,Params) ->


### PR DESCRIPTION
This includes pull request #29, so maybe merge that one first

I used poolboy to keep a pool of connections to Antidote.
When starting a transaction I get a connection from the pool, on commit I return it to the pool. 

I changed the transaction-identifiers to a pair of connection-pid and antidote transaction-id, so that the same transaction can also use the same connection. 

@deepthidevaki can you check if this makes sense?