### PR TITLE
Add Local start script and travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,6 @@ otp_release:
   - 19.1
 script:
   - sed -i 's/{duration,.*}/{duration, 1}/g' test/fmkclient.config
-  - ./runBenchLocal.sh docker
+  - ./runBenchLocal.sh github
 sudo: required
 dist: trusty

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,10 +2,12 @@ language: erlang
 otp_release:
   - 18.3
   - 19.1
+services:
+  - docker  
 install:
   - make all
 script:
   - sed -i 's/{duration,.*}/{duration, 1}/g' test/fmkclient.config
-  - ./runBenchLocal.sh github
+  - ./runBenchLocal.sh docker
 sudo: required
 dist: trusty

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@ language: erlang
 otp_release:
   - 18.3
   - 19.1
+install:
+  - make all
 script:
   - sed -i 's/{duration,.*}/{duration, 1}/g' test/fmkclient.config
   - ./runBenchLocal.sh github

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,9 @@
+language: erlang
+otp_release:
+  - 18.3
+  - 19.1
+script:
+  - sed -i 's/{duration,.*}/{duration, 1}/g' test/fmkclient.config
+  - ./runBenchLocal.sh docker
+sudo: required
+dist: trusty

--- a/Makefile
+++ b/Makefile
@@ -6,14 +6,14 @@ CLIENT=basho_bench_driver_fmkclient
 all: compile rel
 
 compile:
-	${REBAR} compile; \
-	cd ${BENCH}; make all; \
-	cd -; \
-	cp ${BENCH}/include/basho_bench.hrl ./include/ ; \
-	erlc test/${CLIENT}.erl; \
+	${REBAR} compile
+	cd ${BENCH}; make all; cd -
+	cp ${BENCH}/include/basho_bench.hrl ./include/
+	erlc test/${CLIENT}.erl
 	mv ${CLIENT}.beam ${EBIN}/
 
 rel:
+	rm -rf _build/default/rel/fmk/
 	./${REBAR} release
 
 relclean:
@@ -21,7 +21,7 @@ relclean:
 
 bench: compile
 	${BENCH}/_build/default/bin/basho_bench test/fmkclient.config; \
-	Rscript --vanilla ${BENCH}/priv/summary.r -i tests/current
+	-Rscript --vanilla ${BENCH}/priv/summary.r -i tests/current
 
 console: rel
 	./_build/default/rel/fmk/bin/fmk console

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-REBAR=rebar3
+REBAR = $(shell pwd)/rebar3
 BENCH=_build/default/lib/basho_bench
 EBIN=_build/default/lib/fmk/ebin
 CLIENT=basho_bench_driver_fmkclient
@@ -14,7 +14,7 @@ compile:
 
 rel:
 	rm -rf _build/default/rel/fmk/
-	./${REBAR} release
+	${REBAR} release
 
 relclean:
 	rm -rf _build/default/rel

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ relclean:
 	rm -rf _build/default/rel
 
 bench: compile
-	${BENCH}/_build/default/bin/basho_bench test/fmkclient.config; \
+	${BENCH}/_build/default/bin/basho_bench test/fmkclient.config
 	-Rscript --vanilla ${BENCH}/priv/summary.r -i tests/current
 
 console: rel

--- a/README.md
+++ b/README.md
@@ -10,13 +10,62 @@ FMK-- uses rebar3 to build releases and tests, and a local installation is provi
 
 The rebar3 script included in the root directory of the project contains all required information to build FMK. To build a release, run the following command:
 
-```$ rebar3 release```
+```make all```
 
 If the build is successful, you will be able to run FMK by running:
 
-```_build/default/rel/fmk/bin/fmk console```
+```make console```
 
 This will open an erlang VM and from this point on you can use any function in the FMK API.
+
+## Running the Antidote benchmark
+
+To generate graphs for the benchmark [R](https://www.r-project.org/) must be installed (e.g. `sudo apt-get install r-base` on Ubuntu).
+
+### Using runBenchLocal.sh
+
+The script `runBenchLocal.sh` can be used to run the benchmark locally.
+Antidote can either be pulled from Github, run as a docker image, run from a local folder, or an already started Antidote can be used.
+Choose one of the following commands:
+
+    # Use already running Antidote (default)
+    ./runBenchLocal.sh
+
+    # Use a local folder with Antidote
+    ./runBenchLocal.sh /path/to/antidote/
+
+    # Use an Antidote docker image
+    ./runBenchLocal.sh docker
+
+    # Clone Antidote from GitHub, compile and run it:
+    ./runBenchLocal github
+
+
+### Manually
+
+1. Start Antidote.
+
+2. Compile FMK.
+
+        make all
+
+3. Start FMK.
+
+        make console
+
+4. *(optional)* Adjust Benchmark parameters in `test/fmkclient.config`
+
+5. Run the benchmark.
+
+        make bench
+
+6. The results can be found in the `tests` folder.
+
+
+
+
+
+
 
 [1]: https://www.rebar3.org/docs/getting-started
 [2]: https://syncfree.lip6.fr/

--- a/README.md
+++ b/README.md
@@ -53,13 +53,17 @@ Choose one of the following commands:
 
         make console
 
-4. *(optional)* Adjust Benchmark parameters in `test/fmkclient.config`
+4. *(must be executed once)* Fill the database with testdata used by the benchmark.
 
-5. Run the benchmark.
+        ./test/fmk_setup_script.erl
+
+5. *(optional)* Adjust Benchmark parameters in `test/fmkclient.config`
+
+6. Run the benchmark.
 
         make bench
 
-6. The results can be found in the `tests` folder.
+7. The results can be found in the `tests` folder.
 
 
 

--- a/runBenchLocal.sh
+++ b/runBenchLocal.sh
@@ -27,10 +27,17 @@ elif [ $1 = "docker" ]; then
     fi
 elif [ $1 = "github" ]; then
     # clone antidote from github
-    git clone https://github.com/SyncFree/antidote _build/antidote
+    ANTIDOTE_FOLDER=_build/antidote
+    if cd $ANTIDOTE_FOLDER; then
+        echo "Using antidote clone in $ANTIDOTE_FOLDER"
+        # already cloned
+    else
+        git clone https://github.com/SyncFree/antidote $ANTIDOTE_FOLDER
+        cd $ANTIDOTE_FOLDER
+    fi
     # use fixed version
     git checkout 170ab6a57161b56c4d7724b702e8b6c6008aa69b
-    ANTIDOTE_FOLDER=_build/antidote
+    cd $SCRIPTPATH
 else
     # use provided path to antidote
     ANTIDOTE_FOLDER=$1
@@ -44,14 +51,21 @@ fi
 
 cd $SCRIPTPATH
 
+# compile FMK:
 make all
-make rel
+# Start FMK:
 _build/default/rel/fmk/bin/fmk start
+# Start benchmark
 make bench
+
+# Stop FMK
 _build/default/rel/fmk/bin/fmk stop
 
 if [ -n "$ANTIDOTE_FOLDER" ]; then
+    # Stop Antidote
     cd $ANTIDOTE_FOLDER
     _build/default/rel/antidote/bin/env stop
     cd $SCRIPTPATH
 fi
+
+echo "Benchmark done"

--- a/runBenchLocal.sh
+++ b/runBenchLocal.sh
@@ -45,6 +45,8 @@ fi
 
 if [ -n "$ANTIDOTE_FOLDER" ]; then
     cd $ANTIDOTE_FOLDER
+    # clean last release
+    rm -rf _build/default/rel/
     make rel
     _build/default/rel/antidote/bin/env start
 fi
@@ -52,20 +54,35 @@ fi
 cd $SCRIPTPATH
 
 # compile FMK:
+echo "Compiling FMK"
 make all
+
 # Start FMK:
+echo "Starting FMK"
 _build/default/rel/fmk/bin/fmk start
+
+# wait for FMK to start (TODO better way?)
+echo "Waiting for FMK to start"
+sleep 2
+
+# Fill database with testdata:
+echo "Filling Antidote with testdata"
+./test/fmk_setup_script.erl 1 'fmk@127.0.0.1' || true
+
 # Start benchmark
+echo "Starting Benchmark"
 make bench
+echo "Benchmark done"
 
 # Stop FMK
+echo "Stopping FMK"
 _build/default/rel/fmk/bin/fmk stop
 
 if [ -n "$ANTIDOTE_FOLDER" ]; then
     # Stop Antidote
+    echo "Stopping Antidote"
     cd $ANTIDOTE_FOLDER
     _build/default/rel/antidote/bin/env stop
     cd $SCRIPTPATH
 fi
 
-echo "Benchmark done"

--- a/runBenchLocal.sh
+++ b/runBenchLocal.sh
@@ -1,0 +1,57 @@
+#!/bin/bash
+set -e
+
+pushd `dirname $0` > /dev/null
+SCRIPTPATH=`pwd -P`
+popd > /dev/null
+
+ANTIDOTE_FOLDER=""
+
+if [ "$#" -eq 0 ]; then
+    # Assume that Antidote is already running
+    if nc -z localhost 8087; then
+        echo "Antidote is running"
+    else
+        echo "Antidote is not running on PB port 8087"
+        echo "Start Antidote manually, or start the script with a different option."
+        exit 1
+    fi
+elif [ $1 = "docker" ]; then
+    # load antidote from docker:
+    if [ docker inspect antidote ]; then
+        # start existing docker container:
+        docker start antidote
+    else
+        # setup new antidote docker container:
+        docker run -d --name antidote -p "4368:4368" -p "8085:8085" -p "8087:8087" -p "8099:8099" -p "9100:9100" -e NODE_NAME=antidote@127.0.0.1 mweber/antidotedb
+    fi
+elif [ $1 = "github" ]; then
+    # clone antidote from github
+    git clone https://github.com/SyncFree/antidote _build/antidote
+    # use fixed version
+    git checkout 170ab6a57161b56c4d7724b702e8b6c6008aa69b
+    ANTIDOTE_FOLDER=_build/antidote
+else
+    # use provided path to antidote
+    ANTIDOTE_FOLDER=$1
+fi
+
+if [ -n "$ANTIDOTE_FOLDER" ]; then
+    cd $ANTIDOTE_FOLDER
+    make rel
+    _build/default/rel/antidote/bin/env start
+fi
+
+cd $SCRIPTPATH
+
+make all
+make rel
+_build/default/rel/fmk/bin/fmk start
+make bench
+_build/default/rel/fmk/bin/fmk stop
+
+if [ -n "$ANTIDOTE_FOLDER" ]; then
+    cd $ANTIDOTE_FOLDER
+    _build/default/rel/antidote/bin/env stop
+    cd $SCRIPTPATH
+fi

--- a/test/fmk_setup_script.erl
+++ b/test/fmk_setup_script.erl
@@ -6,7 +6,7 @@
 -define (NUM_PHARMACIES, 300).
 -define (NUM_FACILITIES, 50).
 -define (NUM_STAFF, 250).
--define (NUM_PRESCRIPTIONS, 0).
+-define (NUM_PRESCRIPTIONS, 1000).
 -define (ZIPF_SKEW, 1).
 
 
@@ -106,9 +106,9 @@ run_op(FmkNode,create_prescription,Params) ->
 
 run_rpc_op(FmkNode,Op,Params) ->
   ok = case rpc:call(FmkNode,fmk_core,Op,Params) of
-    {error, _} ->
+    {error, Reason} ->
       io:format("Error in ~p with params ~p\n",[Op,Params]),
-      error;
+      {error, Reason};
     ok -> ok
   end.
 

--- a/test/fmkclient.config
+++ b/test/fmkclient.config
@@ -2,7 +2,7 @@
 {mode, max}.
 
 %% test duration
-{duration, 1}.
+{duration, 10}.
 
 % Run 3 concurrent clients
 {concurrent, 3}.

--- a/test/fmkclient.config
+++ b/test/fmkclient.config
@@ -2,7 +2,7 @@
 {mode, max}.
 
 %% test duration
-{duration, 10}.
+{duration, 1}.
 
 % Run 3 concurrent clients
 {concurrent, 3}.


### PR DESCRIPTION
This adds a script to run the benchmark locally  (see changes in Readme to see how invoke it).
The script includes starting Antidote, starting FMK, running the setup script and running the benchmark.

It also adds a Travis-CI config which runs the benchmark for one minute using the Antidote docker image. If you merge this, you can login at https://travis-ci.org and enable the builds for this project.