### PR TITLE
Dynamic config

### DIFF
--- a/config/vars.config
+++ b/config/vars.config
@@ -1,0 +1,5 @@
+%%
+%% etc/vm.args
+%%
+{node,                  "fmk@127.0.0.1"}.
+{cookie,                "antidote"}.

--- a/config/vm.args
+++ b/config/vm.args
@@ -1,8 +1,8 @@
 ## Name of the node
--name fmk@127.0.0.1
+-name ${NODE_NAME}
 
 ## Cookie for distributed erlang
--setcookie antidote
+-setcookie ${COOKIE}
 
 ## Directories with compiled modules
 -pa ./_build/default/lib/*/ebin

--- a/include/fmk.hrl
+++ b/include/fmk.hrl
@@ -1,6 +1,7 @@
 -define(ANTIDOTE, 'antidote@127.0.0.1').
 -define(DEFAULT_ANTIDOTE_PORT, 8087).
 -define(DEFAULT_ANTIDOTE_ADDRESS, "127.0.0.1").
+-define (DEFAULT_FMKE_HTTP_PORT, 9090).
 -define (APP, fmke).
 -define (VAR_ANTIDOTE_PB_PID, antidote_pb_pid).
 -define (VAR_ANTIDOTE_PB_ADDRESS, antidote_pb_address).

--- a/rebar.config
+++ b/rebar.config
@@ -11,13 +11,14 @@
     {antidote_pb, {git, "https://github.com/SyncFree/antidote_pb", {tag, "erlang19"}}},
     {mochiweb, {git, "https://github.com/mochi/mochiweb", {tag, "master"}}},
     {poolboy, {git, "https://github.com/devinus/poolboy", {tag, "1.5.1"}}},
-    {cowboy, {git, "https://github.com/ninenines/cowboy", {tag, "master"}}}
+    {cowboy, {git, "https://github.com/ninenines/cowboy", {tag, "master"}}},
+    {jsx, {git, "https://github.com/talentdeficit/jsx.git", {branch, "v2.8.0"}}}
   ]}.
 
 {relx, [{release, {fmk, "0.0.1"},
          [fmk]},
-         {vm_args, "config/vm.args"},
+        {vm_args, "config/vm.args"},
         {dev_mode, true},
         {include_erts, false},
-
+        {overlay_vars, "config/vars.config"},
         {extended_start_script, true}]}.

--- a/src/fmk_app.erl
+++ b/src/fmk_app.erl
@@ -59,7 +59,7 @@ set_application_variable(ApplicationVariable, EnvironmentVariable, EnvironmentDe
 open_antidote_socket() ->
     set_application_variable(http_port,"HTTP_PORT",?DEFAULT_FMKE_HTTP_PORT),
     set_application_variable(antidote_address,"ANTIDOTE_ADDRESS",?DEFAULT_ANTIDOTE_ADDRESS),
-    set_application_variable(antidote_port,"ANTIDOTE_PORT",?DEFAULT_ANTIDOTE_PORT),
+    set_application_variable(antidote_port,"ANTIDOTE_PB_PORT",?DEFAULT_ANTIDOTE_PORT),
     AntidoteNodeAddress = fmk_config:get_env(?VAR_ANTIDOTE_PB_ADDRESS,?DEFAULT_ANTIDOTE_ADDRESS),
     AntidoteNodePort = fmk_config:get_env(?VAR_ANTIDOTE_PB_PORT,?DEFAULT_ANTIDOTE_PORT),
     {ok, _} =antidote_pool:start([{hostname, AntidoteNodeAddress}, {port, AntidoteNodePort}]),

--- a/src/fmk_app.erl
+++ b/src/fmk_app.erl
@@ -15,21 +15,7 @@
 %%====================================================================
 
 start(_StartType, _StartArgs) ->
-    Dispatch = cowboy_router:compile([
-  		{'_', [
-  			{"/prescriptions/[:id]", prescription_handler, []},
-        {"/patients/[:id]", patient_handler, []},
-        {"/pharmacies/[:id]", pharmacy_handler, []},
-        {"/facilities/[:id]", facility_handler, []},
-        {"/treatments/[:id]", treatment_handler, []},
-        {"/events/[:id]", event_handler, []},
-        {"/staff/[:id]", staff_handler, []}
-  		]}
-  	]),
-  	{ok, _} = cowboy:start_clear(http, 100, [{port, 9090}], #{
-  		env => #{dispatch => Dispatch}
-  	}),
-    case fmk_sup:start_link() of
+    Result = case fmk_sup:start_link() of
         {ok, Pid} ->
               case open_antidote_socket() of
                 ok -> {ok, Pid};
@@ -37,7 +23,23 @@ start(_StartType, _StartArgs) ->
               end;
         {error, Reason} ->
               {error, Reason}
-    end.
+    end,
+    Dispatch = cowboy_router:compile([
+      {'_', [
+        {"/prescriptions/[:id]", prescription_handler, []},
+        {"/patients/[:id]", patient_handler, []},
+        {"/pharmacies/[:id]", pharmacy_handler, []},
+        {"/facilities/[:id]", facility_handler, []},
+        {"/treatments/[:id]", treatment_handler, []},
+        {"/events/[:id]", event_handler, []},
+        {"/staff/[:id]", staff_handler, []}
+      ]}
+    ]),
+    HttpPort = list_to_integer(fmk_config:get(http_port,9090)),
+    {ok, _} = cowboy:start_clear(http, 100, [{port, HttpPort}], #{
+      env => #{dispatch => Dispatch}
+    }),
+    Result.
 
 %%--------------------------------------------------------------------
 stop(_State) ->
@@ -55,6 +57,7 @@ set_application_variable(ApplicationVariable, EnvironmentVariable, EnvironmentDe
   Value.
 
 open_antidote_socket() ->
+    set_application_variable(http_port,"HTTP_PORT",?DEFAULT_FMKE_HTTP_PORT),
     set_application_variable(antidote_address,"ANTIDOTE_ADDRESS",?DEFAULT_ANTIDOTE_ADDRESS),
     set_application_variable(antidote_port,"ANTIDOTE_PORT",?DEFAULT_ANTIDOTE_PORT),
     AntidoteNodeAddress = fmk_config:get_env(?VAR_ANTIDOTE_PB_ADDRESS,?DEFAULT_ANTIDOTE_ADDRESS),

--- a/src/patient_handler.erl
+++ b/src/patient_handler.erl
@@ -29,6 +29,7 @@ create_patient(Req) ->
 		{<<"name">>, Name},
 		{<<"address">>, Address}
 		], _Req0} = cowboy_req:read_urlencoded_body(Req),
+		io:format("~p\n",[jsx:decode(cowboy_req:body(Req))]),
 		IntegerId = binary_to_integer(Id),
 		case IntegerId =< ?MIN_ID of
 				true ->


### PR DESCRIPTION
Add dynamic port for listening to HTTP requests, dynamic node name for starting multiple nodes in a single machine. Replaces #36.