### PR TITLE
Improve test orchestration, remove need for external bash scripts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,9 +7,9 @@ services:
   - docker
 install:
   - make all
-script:
   - make lint
   - make xref
+script:
   - make eunit
   - make ct
   - make bench

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,7 @@ install:
   - make lint
   - make xref
 script:
-  - make eunit
-  - make ct
+  - make test
   - make bench
   - make test-multiple-releases
   - rebar3 as test coveralls send

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,8 @@ install:
   - make all
   - make lint
   - make xref
+before_script:
+  - epmd -daemon
 script:
   - make test
   - make bench

--- a/Makefile
+++ b/Makefile
@@ -38,33 +38,8 @@ compile:
 console: rel
 	./_build/default/rel/fmke/bin/env console
 
-ct: all
-	./travis.sh ct antidote
-	./travis.sh ct antidote_norm
-	./travis.sh ct redis
-	./travis.sh ct riak
-	./travis.sh ct riak_norm
-
-ct-antidote: rel
-	./travis.sh ct antidote
-
-ct-antidote-norm: rel
-	./travis.sh ct antidote_norm
-
-ct-redis: rel
-	./travis.sh ct redis
-
-ct-riak: rel
-	./travis.sh ct riak
-
-ct-riak-norm: rel
-	./travis.sh ct riak_norm
-
 dialyzer:
 	${REBAR} dialyzer
-
-eunit:
-	rebar3 eunit
 
 kv_driver_test:
 	ct_run -pa ./_build/default/lib/*/ebin -logdir logs -suite test/ct/kv_driver_SUITE
@@ -141,6 +116,10 @@ stop-redis:
 
 stop-riak:
 	./scripts/stop_data_store.sh riak
+
+test: all
+	rebar3 eunit
+	rebar3 ct
 
 test-multiple-releases:
 	rm -rf _build/default/rel

--- a/elvis.config
+++ b/elvis.config
@@ -28,7 +28,7 @@
                   {elvis_style, state_record_and_type},
                   {elvis_style, no_spec_with_records},
                   {elvis_style, dont_repeat_yourself, #{min_complexity => 30}},
-                  {elvis_style, no_debug_call, #{ignore => []}}],
+                  {elvis_style, no_debug_call, #{ignore => [fmke_test_utils]}}],
                   %% sequential reporter calls other reporters dynamically
                   % {elvis_style, invalid_dynamic_call, #{ignore => [oc_sequential_reporter]}}],
 
@@ -41,7 +41,8 @@
                   {elvis_style, line_length, #{limit => 120}},
                   %% be a bit more lax on naming for tests
                   {elvis_style, variable_naming_convention, #{regex => "^_{0,2}([A-Z][0-9a-zA-Z]*)$"}},
-                  {elvis_style, state_record_and_type, disable}],
+                  {elvis_style, state_record_and_type, disable},
+                  {elvis_style, no_debug_call, #{ignore => [fmke_test_utils]}}],
         ruleset => erl_files
       },
       #{dirs => ["."],

--- a/include/fmke.hrl
+++ b/include/fmke.hrl
@@ -1,8 +1,17 @@
 -define (APP, fmke).
+-define (OPTIONS, [adapter, connection_pool_size, database_addresses, database_ports, http_port, target_database]).
+-define (DEFAULTS, #{
+    adapter => fmke_ndm_adapter,
+    connection_pool_size => 64,
+    database_addresses => ["127.0.0.1"],
+    database_ports => [8087],
+    http_port => 9090,
+    target_database => antidote
+}).
+
+-define (TIMEOUT, 60000).
 
 -define (CONFIG_FILE_PATH, "/config/fmke.config").
--define (DEFAULT_HTTP_PORT, 9090).
--define (DEFAULT_CONN_SIZE, 32).
 
 %% TODO move this to an ETS table
 -define(SUPPORTED_DBS, [antidote, antidote_norm, riak_kv, riak_kv_norm, redis]).

--- a/rebar.config
+++ b/rebar.config
@@ -7,7 +7,7 @@
     {cowboy, "~>2.2"},
     {riak_client, "~>2.5"},
     %% Non-hex dependencies in legacy mode
-    {antidote_pb, {git, "https://github.com/SyncFree/antidote_pb", {tag, "erlang19"}}}
+    {antidote_pb, {git, "https://github.com/SyncFree/antidote_pb", {tag, "error-handling"}}}
 ]}.
 
 {eunit_opts, [

--- a/rebar.lock
+++ b/rebar.lock
@@ -1,7 +1,7 @@
 {"1.1.0",
 [{<<"antidote_pb">>,
   {git,"https://github.com/SyncFree/antidote_pb",
-       {ref,"eb59f91ec8fa111dbbb50e399c181d1ab57bcb96"}},
+       {ref,"09a2f884a6e0b388475576701b096741d48f48fb"}},
   0},
  {<<"cowboy">>,{pkg,<<"cowboy">>,<<"2.2.0">>},0},
  {<<"cowlib">>,{pkg,<<"cowlib">>,<<"2.1.0">>},1},

--- a/src/fmke_config.erl
+++ b/src/fmke_config.erl
@@ -28,18 +28,44 @@ set(Key, Value) ->
     fmke_mochiglobal:put(Key, Value).
 
 read_config_file() ->
-    {ok, CurrentDirectory} = file:get_cwd(),
-    ConfigFile = CurrentDirectory ++ ?CONFIG_FILE_PATH,
-    {ok, AppProps} = file:consult(ConfigFile),
-    read_app_props(AppProps).
+    try
+        {ok, CurrentDirectory} = file:get_cwd(),
+        ConfigFile = CurrentDirectory ++ ?CONFIG_FILE_PATH,
+        {ok, AppProps} = file:consult(ConfigFile),
+        config(AppProps),
+        setup_env()
+    catch
+        _:Reason ->
+            lager:info("Error reading from config file: ~p", [Reason]),
+            lager:info("Could not read from config file, reverting to environment and default values..."),
+            config([]),
+            setup_env()
+    end.
 
-read_app_props(Props) ->
+%% Sets all options needed to start FMKe, from the 4 following sources, ordered by priority:
+%% OS Environment, Application Environment, config file, default value
+config(ConfigProps) ->
+    lists:foreach(
+        fun(Param) ->
+            {Source, Value} = get_value(os:getenv(atom_to_list(Param)), application:get_env(?APP, Param),
+                                        proplists:get_value(Param, ConfigProps), maps:get(Param, ?DEFAULTS)),
+            lager:info("~p option '~p' read from ~p, set to ~p", [?APP, Param, Source, Value]),
+            ok = application:set_env(?APP, Param, Value)
+        end,
+    ?OPTIONS).
+
+get_value(false, undefined, undefined, Val) -> {defaults, Val};
+get_value(false, undefined, Val, _) -> {config_file, Val};
+get_value(false, {ok, Val}, _, _) -> {app_env, Val};
+get_value(Val, _, _, _) -> {os_env, Val}.
+
+setup_env() ->
     %% read properties from the config file
-    HttpPort = proplists:get_value(http_port, Props, ?DEFAULT_HTTP_PORT),
-    ConnPoolSize = proplists:get_value(connection_pool_size, Props, ?DEFAULT_CONN_SIZE),
-    DbAddressList = proplists:get_value(database_addresses, Props, []),
-    DbPortList = proplists:get_value(database_ports, Props, []),
-    TargetDatabase = proplists:get_value(target_database, Props),
+    HttpPort = application:get_env(?APP, http_port),
+    ConnPoolSize = application:get_env(?APP, connection_pool_size),
+    DbAddressList = application:get_env(?APP, database_addresses),
+    DbPortList = application:get_env(?APP, database_ports),
+    TargetDatabase = application:get_env(?APP, target_database),
 
     %% check for correct input from the config file
     true = is_integer(HttpPort) andalso HttpPort > 0 andalso HttpPort =< 65535,
@@ -177,42 +203,6 @@ supported_db(_Database) ->
 
 -ifdef(TEST).
 -include_lib("eunit/include/eunit.hrl").
-
-empty_prop_list_test() ->
-    ?assertException(error, {badmatch, {error, no_addresses}}, read_app_props([])).
-
-invalid_http_port_config_test() ->
-    Props = [{connection_pool_size, 32}, {database_addresses, [{127, 0, 0, 1}]},
-             {database_ports, [8087]}, {target_database, riak}],
-    ?assertException(error, {badmatch, false}, read_app_props([{http_port, -443} | Props])),
-    ?assertException(error, {badmatch, false}, read_app_props([{http_port, 70000} | Props])).
-
-invalid_conn_size_config_test() ->
-    Props = [{http_port, 9090}, {database_addresses, [{127, 0, 0, 1}]},
-             {database_ports, [8087]}, {target_database, riak}],
-    ?assertException(error, {badmatch, false}, read_app_props([{connection_pool_size, -32} | Props])),
-    ?assertException(error, {badmatch, false}, read_app_props([{connection_pool_size, 0} | Props])).
-
-missing_http_port_conn_size_returns_valid_config_test() ->
-    Props = [{database_addresses, [{127, 0, 0, 1}]},
-             {database_ports, [8087]}, {target_database, riak}],
-    [
-        {driver, fmke_kv_driver}, {simplified_driver, fmke_db_driver_riak_kv}, {db_conn_hostnames, ["127.0.0.1"]},
-        {db_conn_ports, [8087]}, {db_conn_pool_size, ?DEFAULT_CONN_SIZE}, {http_port, ?DEFAULT_HTTP_PORT}
-    ] = read_app_props(Props).
-
-missing_address_list_config_test() ->
-    Props = [{database_ports, [8087]}, {target_database, riak}],
-    ?assertException(error, {badmatch, {error, no_addresses}}, read_app_props(Props)).
-
-missing_port_list_config_test() ->
-    Props = [{database_addresses, ["127.0.0.1"]}, {target_database, riak}],
-    ?assertException(error, {badmatch, {error, no_ports}}, read_app_props(Props)).
-
-unsupported_db_config_test() ->
-    Props = [{database_addresses, ["127.0.0.1"]}, {database_ports, [8087]}],
-    ?assertException(error, {badmatch, false}, read_app_props([{target_database, undefined} | Props])),
-    ?assertException(error, {badmatch, false}, read_app_props(Props)).
 
 mochiglobal_application_state_test() ->
     undefined = ?MODULE:get(something),

--- a/src/fmke_config.erl
+++ b/src/fmke_config.erl
@@ -61,11 +61,11 @@ get_value(Val, _, _, _) -> {os_env, Val}.
 
 setup_env() ->
     %% read properties from the config file
-    HttpPort = application:get_env(?APP, http_port),
-    ConnPoolSize = application:get_env(?APP, connection_pool_size),
-    DbAddressList = application:get_env(?APP, database_addresses),
-    DbPortList = application:get_env(?APP, database_ports),
-    TargetDatabase = application:get_env(?APP, target_database),
+    {ok, HttpPort} = application:get_env(?APP, http_port),
+    {ok, ConnPoolSize} = application:get_env(?APP, connection_pool_size),
+    {ok, DbAddressList} = application:get_env(?APP, database_addresses),
+    {ok, DbPortList} = application:get_env(?APP, database_ports),
+    {ok, TargetDatabase} = application:get_env(?APP, target_database),
 
     %% check for correct input from the config file
     true = is_integer(HttpPort) andalso HttpPort > 0 andalso HttpPort =< 65535,

--- a/test/ct/fmke_core_unit_test_SUITE.erl
+++ b/test/ct/fmke_core_unit_test_SUITE.erl
@@ -3,11 +3,16 @@
 -include("fmke.hrl").
 -include("fmk_kv.hrl").
 
+-define (NODENAME, 'fmke@127.0.0.1').
+-define (COOKIE, fmke).
+
 %%%-------------------------------------------------------------------
 %%% Common Test exports
 %%%-------------------------------------------------------------------
 -export([
+    suite/0,
     all/0,
+    groups/0,
     init_per_suite/1,
     end_per_suite/1,
     init_per_group/2,
@@ -34,30 +39,69 @@
 %%% Common Test Callbacks
 %%%-------------------------------------------------------------------
 
+suite() ->
+    [{timetrap, {seconds, 90}}].
+
 %% returns a list of all test sets to be executed by Common Test.
 all() ->
-    [event_unit_tests, facility_unit_tests, patient_unit_tests,
-    pharmacy_unit_tests, prescription_unit_tests, staff_unit_tests,
-    treatment_unit_tests].
+    [{group, antidote}, {group, redis}, {group, riak}].
 
 %%%-------------------------------------------------------------------
 %%% Common Test configuration
 %%%-------------------------------------------------------------------
 
 init_per_suite(Config) ->
-    TargetNode = 'fmke@127.0.0.1',
-    {ok, _} = net_kernel:start(['fmke_ct_test@127.0.0.1', longnames]),
-    true = erlang:set_cookie('fmke_ct_test@127.0.0.1', fmke),
-    [{node, TargetNode} | Config].
-
-end_per_suite(Config) ->
+    {ok, _} = net_kernel:start(['fmke_ct_test@127.0.0.1']),
+    true = erlang:set_cookie('fmke_ct_test@127.0.0.1', ?COOKIE),
     Config.
 
+end_per_suite(_Config) ->
+    net_kernel:stop(),
+    ok.
+
+groups() ->
+    [{antidote, [shuffle, sequence], [
+        event_unit_tests, facility_unit_tests, patient_unit_tests, pharmacy_unit_tests,
+        prescription_unit_tests, staff_unit_tests, treatment_unit_tests
+    ]},
+    {riak, [shuffle, sequence], [
+        event_unit_tests, facility_unit_tests, patient_unit_tests, pharmacy_unit_tests,
+        prescription_unit_tests, staff_unit_tests, treatment_unit_tests
+    ]},
+    {redis, [shuffle, sequence], [
+        event_unit_tests, facility_unit_tests, patient_unit_tests, pharmacy_unit_tests,
+        prescription_unit_tests, staff_unit_tests, treatment_unit_tests
+    ]}].
+
+init_per_group(antidote, Config) ->
+    Node = fmke_test_utils:start_node_with_antidote_backend(?NODENAME),
+    erlang:set_cookie(?NODENAME, ?COOKIE),
+    [{node, Node} | Config];
+init_per_group(riak, Config) ->
+    Node = fmke_test_utils:start_node_with_riak_backend(?NODENAME),
+    erlang:set_cookie(?NODENAME, ?COOKIE),
+    [{node, Node} | Config];
+init_per_group(redis, Config) ->
+    Node = fmke_test_utils:start_node_with_redis_backend(?NODENAME),
+    erlang:set_cookie(?NODENAME, ?COOKIE),
+    [{node, Node} | Config];
 init_per_group(_, Config) ->
     Config.
 
-end_per_group(_, Config) ->
-    Config.
+end_per_group(antidote, _Config) ->
+    fmke_test_utils:stop_antidote(),
+    ct_slave:stop(?NODENAME),
+    ok;
+end_per_group(riak, _Config) ->
+    fmke_test_utils:stop_riak(),
+    ct_slave:stop(?NODENAME),
+    ok;
+end_per_group(redis, _Config) ->
+    fmke_test_utils:stop_redis(),
+    ct_slave:stop(?NODENAME),
+    ok;
+end_per_group(_, _Config) ->
+    ok.
 
 init_per_testcase(facility_unit_tests, Config) ->
     TabId = ets:new(facilities, [set, protected, named_table]),

--- a/test/fmke_test_utils.erl
+++ b/test/fmke_test_utils.erl
@@ -1,0 +1,99 @@
+-module(fmke_test_utils).
+-include_lib("common_test/include/ct.hrl").
+
+-include ("fmke.hrl").
+
+-export ([
+    start_antidote/0,
+    start_riak/0,
+    start_redis/0,
+    stop_antidote/0,
+    stop_riak/0,
+    stop_redis/0,
+    start_node_with_antidote_backend/1,
+    start_node_with_riak_backend/1,
+    start_node_with_redis_backend/1
+]).
+
+start_antidote() ->
+    os:cmd("docker run -d --name antidote -e NODE_NAME=antidote@127.0.0.1 "
+           "-p \"4368:4368\" -p \"8085:8085\" -p \"8087:8087\" -p \"8099:8099\" -p \"9100:9100\" mweber/antidotedb"),
+    timer:sleep(5000).
+
+stop_antidote() ->
+    os:cmd("docker stop antidote && docker rm antidote").
+
+start_riak() ->
+    os:cmd("docker run -d --name riak -p \"8087:8087\" -p \"8098:8098\" -e NODE_NAME=riak@127.0.0.1 goncalotomas/riak"),
+    timer:sleep(17500).
+
+stop_riak() ->
+    os:cmd("docker stop riak && docker rm riak").
+
+start_redis() ->
+    os:cmd("docker run -d --name redis -p \"6379:6379\" redis"),
+    timer:sleep(2500).
+
+stop_redis() ->
+    os:cmd("docker stop redis && docker rm redis").
+
+start_node_with_antidote_backend(Name) ->
+    fmke_test_utils:start_antidote(),
+    start_local_node(Name, antidote, 8087).
+
+start_node_with_riak_backend(Name) ->
+    fmke_test_utils:start_riak(),
+    start_local_node(Name, riak, 8087).
+
+start_node_with_redis_backend(Name) ->
+    fmke_test_utils:start_redis(),
+    start_local_node(Name, redis, 6379).
+
+start_local_node(Name, Database, Port) ->
+    io:format("Trying to spawn node ~p and connect it to ~p running on port ~p...", [Name, Database, Port]),
+    CodePath = lists:filter(fun filelib:is_dir/1, code:get_path()),
+    %% have the slave nodes monitor the runner node, so they can't outlive it
+    NodeConfig = [{monitor_master, true}, {startup_functions, [{code, set_path, [CodePath]}]}],
+    case ct_slave:start(Name, NodeConfig) of
+        {ok, Node} ->
+            ok = rpc:call(Node, application, set_env, [?APP, target_database, Database]),
+            ok = rpc:call(Node, application, set_env, [?APP, connection_pool_size, 64]),
+            ok = rpc:call(Node, application, set_env, [?APP, database_addresses, ["127.0.0.1"]]),
+            ok = rpc:call(Node, application, set_env, [?APP, database_ports, [Port]]),
+            ok = rpc:call(Node, application, set_env, [?APP, http_port, 9090]),
+
+            ClientLib = get_client_lib(Database),
+            ok = rpc:call(Node, application, load, [ClientLib]),
+            %% start the application remotely
+            {ok, _} = rpc:call(Node, application, ensure_all_started, [?APP]),
+            io:format("Node ~p started", [Node]),
+            Node;
+        {error, Reason, Node} ->
+            io:format("Error starting node ~w, reason ~w, will retry", [Node, Reason]),
+            ct_slave:stop(Name),
+            wait_until_offline(Node),
+            start_local_node(Name, Database, Port)
+    end.
+
+wait_until_offline(Node) ->
+    wait_until(fun() -> pang == net_adm:ping(Node) end, 60*2, 500).
+
+wait_until(Fun, Retry, Delay) when Retry > 0 ->
+    wait_until_result(Fun, true, Retry, Delay).
+
+wait_until_result(Fun, Result, Retry, Delay) when Retry > 0 ->
+    Res = Fun(),
+    case Res of
+        Result ->
+            ok;
+        _ when Retry == 1 ->
+            {fail, Res};
+        _ ->
+            timer:sleep(Delay),
+            wait_until_result(Fun, Result, Retry-1, Delay)
+end.
+
+-spec get_client_lib(Database :: antidote | riak | redis) -> atom().
+get_client_lib(antidote) -> antidote_pb;
+get_client_lib(riak) -> riak_pb;
+get_client_lib(redis) -> eredis.

--- a/travis.sh
+++ b/travis.sh
@@ -1,19 +1,8 @@
 #!/bin/bash
 set -e
 
-if [ $1 = "test" ]; then
-    if [ $2 = "fmke" ]; then
-        echo "running FMKe tests..."
-        # TODO maybe perform unit tests with ets or other built in erlang utility...
-        # TODO maybe run dialyzer...
-        echo "done"
-    else
-        ./scripts/run_fmke_operations.sh $2
-    fi
-elif [ $1 = "ct" ]; then
-          ./scripts/run_ct_suite.sh $2
-elif [ $1 = "bench" ]; then
-        ./scripts/run_benchmark.sh $2 $3
+if [ $1 = "bench" ]; then
+    ./scripts/run_benchmark.sh $2 $3
 else
     echo "fatal: unknown operation."
     exit 1


### PR DESCRIPTION
The `rebar3 ct` was being run through a makefile target to be able to start and stop all databases and run the same CT suite on multiple back ends. This PR deals with this issue by using `os:cmd` to start and stop the databases, and keeping an utility test module under `/test`.

`make test` now runs all Common Test and Eunit tests.

Revisited the travis script to make sure only needed logic is kept.
Also moves `make lint`, `make xref` to the install steps of Travis.