### PR TITLE
Load all client dependencies, start only those required

### DIFF
--- a/src/fmke.app.src
+++ b/src/fmke.app.src
@@ -11,16 +11,14 @@
     poolboy,
     lager,
     cowboy,
-    jsx,
-    antidotec_pb,
-    riak_pb,
-    riak_client,
-    eredis,
-    eredis_cluster
+    jsx
    ]},
-
+  {included_applications, [
+    antidotec_pb,
+    riak_client,
+    eredis_cluster
+  ]},
   {modules, []},
-
   {maintainers, ["Goncalo Tomas"]},
   {licenses, ["Apache 2"]},
   {links, [{"Github","https://github.com/goncalotomas/FMKe"}]}

--- a/src/fmke_driver_opt_antidote.erl
+++ b/src/fmke_driver_opt_antidote.erl
@@ -73,6 +73,7 @@ stop(_) ->
     gen_server:stop(?SERVER).
 
 init([]) ->
+    {ok, _Started} = application:ensure_all_started(antidotec_pb),
     {ok, []}.
 
 create_patient(Id, Name, Address) ->

--- a/src/fmke_driver_opt_redis_cluster.erl
+++ b/src/fmke_driver_opt_redis_cluster.erl
@@ -59,7 +59,7 @@ stop(_) ->
 
 init([Hosts, Ports, PoolSize]) ->
     InitNodes = lists:zip(Hosts, Ports),
-    application:ensure_all_started(eredis_cluster),
+    {ok, _Started} = application:ensure_all_started(eredis_cluster),
     application:set_env(eredis_cluster, pool_size, PoolSize),
     application:set_env(eredis_cluster, pool_max_overflow, 2*PoolSize),
     eredis_cluster:connect(InitNodes),

--- a/src/fmke_driver_opt_riak_kv.erl
+++ b/src/fmke_driver_opt_riak_kv.erl
@@ -54,6 +54,7 @@ stop(_) ->
     gen_server:call(?MODULE, stop).
 
 init(_) ->
+    {ok, _Started} = application:ensure_all_started(riak_client),
     {ok, {}}.
 
 handle_cast(_Msg, State) ->


### PR DESCRIPTION
This PR fixes a previous behaviour where every client library was loaded and started at the beginning. Now _all_ client dependencies are loaded, but the drivers themselves must start the client applications manually, giving them a bit more control and also removing potential overhead from loading all of the dependencies.