### PR TITLE
add default shell nodename and cookie

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -74,3 +74,8 @@
 {xref_checks, [
    deprecated_function_calls, deprecated_functions, undefined_function_calls, undefined_functions
 ]}.
+
+{dist_node, [
+    {name, 'fmke@127.0.0.1'},
+    {setcookie, fmke}
+]}.

--- a/test/fmke_antidote_transactions_SUITE.erl
+++ b/test/fmke_antidote_transactions_SUITE.erl
@@ -69,12 +69,7 @@ end_per_testcase(_TestCase, _Config) ->
 %% TestCase = atom()
 %% Reason = term()
 %%--------------------------------------------------------------------
-all() ->
-    [
-        read_read_succeds
-        ,read_write_succeeds
-        ,write_write_aborts
-    ].
+all() -> [read_read_succeds, read_write_succeeds, write_write_aborts].
 
 read_read_succeds(_Config) ->
     Key = list_to_binary(rand_str:get(64)),
@@ -161,10 +156,10 @@ write_write_aborts(_Config) ->
     ok.
 
 checkin_remote_pid(Pid) ->
-    rpc(fmke_db_conn_manager,checkout, [Pid]).
+    rpc(fmke_db_conn_manager, checkout, [Pid]).
 
 checkout_remote_pid() ->
-    rpc(fmke_db_conn_manager,checkout, []).
+    rpc(fmke_db_conn_manager, checkout, []).
 
 rpc(Mod, Fun, Args) ->
     rpc:call(?NODENAME, Mod, Fun, Args).

--- a/test/fmke_antidote_transactions_SUITE.erl
+++ b/test/fmke_antidote_transactions_SUITE.erl
@@ -25,8 +25,9 @@ suite() ->
 %% Reason = term()
 %%--------------------------------------------------------------------
 init_per_suite(Config) ->
-    {ok, _} = net_kernel:start(['fmke_antidote_ct@127.0.0.1']),
-    true = erlang:set_cookie('fmke_antidote_ct@127.0.0.1', ?COOKIE),
+    TestNode = 'fmke_antidote_ct@127.0.0.1',
+    ok = fmke_test_setup:ensure_start_dist_node(TestNode),
+    true = erlang:set_cookie(TestNode, ?COOKIE),
     fmke_test_setup:start_node_with_antidote_backend(?NODENAME, true, non_nested),
     true = erlang:set_cookie(?NODENAME, ?COOKIE),
     Config.

--- a/test/fmke_core_unit_test_SUITE.erl
+++ b/test/fmke_core_unit_test_SUITE.erl
@@ -63,7 +63,7 @@ init_per_suite(Config) ->
     OptionValues = lists:map(fun(Opt) ->
                         {Opt, ct:get_config(Opt, ?DEFAULT(Opt))}
                     end, ?OPTIONS),
-    {ok, _} = net_kernel:start([CTNodename]),
+    ok = fmke_test_setup:ensure_start_dist_node(CTNodename),
     true = erlang:set_cookie(CTNodename, ?COOKIE),
     Node = fmke_test_setup:launch_app(FMKeNodename, OptionValues),
     [{node, Node} | Config].

--- a/test/fmke_db_conn_manager_SUITE.erl
+++ b/test/fmke_db_conn_manager_SUITE.erl
@@ -25,8 +25,9 @@ suite() ->
 %% Reason = term()
 %%--------------------------------------------------------------------
 init_per_suite(Config) ->
-    {ok, _} = net_kernel:start(['fmke_db_conn_mgr_test@127.0.0.1']),
-    true = erlang:set_cookie('fmke_db_conn_mgr_test@127.0.0.1', ?COOKIE),
+    TestNode = 'fmke_db_conn_mgr_test@127.0.0.1',
+    ok = fmke_test_setup:ensure_start_dist_node(TestNode),
+    true = erlang:set_cookie(TestNode, ?COOKIE),
     fmke_test_setup:start_node_with_mock_cluster(?NODENAME, true, non_nested),
     true = erlang:set_cookie(?NODENAME, ?COOKIE),
     Config.

--- a/test/fmke_http_api_SUITE.erl
+++ b/test/fmke_http_api_SUITE.erl
@@ -58,7 +58,7 @@ init_per_suite(Config) ->
     OptionValues = lists:map(fun(Opt) ->
                         {Opt, ct:get_config(Opt, ?DEFAULT(Opt))}
                     end, ?OPTIONS),
-    {ok, _} = net_kernel:start([CTNodename]),
+    ok = fmke_test_setup:ensure_start_dist_node(CTNodename),
     true = erlang:set_cookie(CTNodename, ?COOKIE),
     Node = fmke_test_setup:launch_app(FMKeNodename, OptionValues),
     [{node, Node} | Config].

--- a/test/fmke_test_setup.erl
+++ b/test/fmke_test_setup.erl
@@ -13,6 +13,7 @@
     start_node_with_riak_backend/3,
     start_node_with_mock_cluster/3,
     launch_app/2,
+    ensure_start_dist_node/1,
     stop_all/0,
     stop_antidote/0,
     stop_riak/0,
@@ -159,6 +160,19 @@ launch_app(Nodename, Config) ->
     [Port] = proplists:get_value(database_ports, Config),
     ok = start_db(Database, Port),
     start_node(Nodename, Config).
+
+ensure_start_dist_node(Nodename) ->
+    case node() of
+        'nonode@nohost' ->
+            {ok, _} = net_kernel:start([Nodename]),
+            ok;
+        Nodename ->
+            ok;
+        _Else ->
+            ok = net_kernel:stop(),
+            {ok, _} = net_kernel:start([Nodename]),
+            ok
+    end.
 
 start_db(antidote, Port) ->
     start_antidote(Port);


### PR DESCRIPTION
Fixes an issue described in #201 where no nodename can make it complicated to run an example benchmark run with `rebar3 shell`